### PR TITLE
[ALLUXIO-3015]update jets3t version from 0.8.1 to 0.9.4 to meet only signature v4 in cn-north-1 aws s3 region

### DIFF
--- a/underfs/s3n/pom.xml
+++ b/underfs/s3n/pom.xml
@@ -54,7 +54,6 @@
     <maven.version>3.3.9</maven.version>
   </properties>
 
-
   <dependencyManagement>
     <dependencies>
       <!-- External dependencies -->
@@ -83,7 +82,6 @@
         <version>${project.version}</version>
         <type>test-jar</type>
       </dependency>
-
 
       <!-- External test dependencies -->
       <dependency>

--- a/underfs/s3n/pom.xml
+++ b/underfs/s3n/pom.xml
@@ -18,7 +18,6 @@
   <description>S3 Under File System implementation (Legacy)</description>
   <version>1.6.0-SNAPSHOT</version>
 
-
   <repositories>
     <repository>
       <id>central</id>

--- a/underfs/s3n/pom.xml
+++ b/underfs/s3n/pom.xml
@@ -18,6 +18,7 @@
   <description>S3 Under File System implementation (Legacy)</description>
   <version>1.6.0-SNAPSHOT</version>
 
+
   <repositories>
     <repository>
       <id>central</id>
@@ -48,11 +49,12 @@
     <alluxio.version>1.6.0-SNAPSHOT</alluxio.version>
     <build.path>build</build.path>
     <java.version>1.7</java.version>
-    <jets3t.version>0.8.1</jets3t.version>
+    <jets3t.version>0.9.4</jets3t.version>
     <junit.version>4.12</junit.version>
     <log4j.version>1.2.17</log4j.version>
     <maven.version>3.3.9</maven.version>
   </properties>
+
 
   <dependencyManagement>
     <dependencies>
@@ -82,6 +84,7 @@
         <version>${project.version}</version>
         <type>test-jar</type>
       </dependency>
+
 
       <!-- External test dependencies -->
       <dependency>


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3015
update jets3t to 0.9.4 fix the problem alluxio can not mount aws s3 region cn-north-1 in china , because jets3t version 0.8.1 do not support signature V4, AWS other regions support both signature V2 & V4 while cn-north-1 is a new region which only support signature V4.