### PR TITLE
obs: add pom settings to mvn deploy to S3

### DIFF
--- a/underfs/obs/pom.xml
+++ b/underfs/obs/pom.xml
@@ -18,6 +18,17 @@
   <description>Huawei OBS Under File System implementation</description>
   <version>1.8.0-SNAPSHOT</version>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>maven.alluxio</id>
+      <url>s3://maven.alluxio/snapshot</url>
+    </snapshotRepository>
+    <repository>
+      <id>maven.alluxio</id>
+      <url>s3://maven.alluxio/release</url>
+    </repository>
+  </distributionManagement>
+
   <repositories>
     <repository>
       <id>central</id>
@@ -51,6 +62,10 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+    </repository>
+    <repository>
+      <id>maven.alluxio</id>
+      <url>s3://maven.alluxio/release</url>
     </repository>
   </repositories>
 
@@ -184,6 +199,14 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <extensions>
+      <extension>
+        <groupId>org.kuali.maven.wagons</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.2.1</version>
+      </extension>
+    </extensions>
 
     <plugins>
       <plugin>

--- a/underfs/obs/pom.xml
+++ b/underfs/obs/pom.xml
@@ -20,12 +20,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>maven.alluxio</id>
-      <url>s3://maven.alluxio/snapshot</url>
+      <id>alluxio-extensions</id>
+      <url>s3://alluxio-extensions/snapshot</url>
     </snapshotRepository>
     <repository>
-      <id>maven.alluxio</id>
-      <url>s3://maven.alluxio/release</url>
+      <id>alluxio-extensions</id>
+      <url>s3://alluxio-extensions/release</url>
     </repository>
   </distributionManagement>
 
@@ -64,8 +64,8 @@
       </snapshots>
     </repository>
     <repository>
-      <id>maven.alluxio</id>
-      <url>s3://maven.alluxio/release</url>
+      <id>alluxio-extensions</id>
+      <url>s3://alluxio-extensions/release</url>
     </repository>
   </repositories>
 

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
@@ -55,6 +55,9 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
   /** Bucket name of user's configured Alluxio bucket. */
   private final String mBucketName;
 
+  /** Header prefix. */
+  public static final String HEADER_OBS = "obs://";
+
   /**
    * Constructs a new instance of {@link OBSUnderFileSystem}.
    *
@@ -254,7 +257,7 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   protected String getRootKey() {
-    return Constants.HEADER_OBS + mBucketName;
+    return HEADER_OBS + mBucketName;
   }
 
   @Override

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystemFactory.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystemFactory.java
@@ -54,7 +54,7 @@ public class OBSUnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public boolean supportsPath(String path) {
-    return path != null && path.startsWith(Constants.HEADER_OBS);
+    return path != null && path.startsWith(OBSUnderFileSystem.HEADER_OBS);
   }
 
   /**

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
@@ -65,7 +65,9 @@ public class OBSOutputStreamTest {
   @Test
   @PrepareForTest(OBSOutputStream.class)
   public void testConstructor() throws Exception {
-    PowerMockito.whenNew(File.class).withArguments(Mockito.anyString()).thenReturn(mFile);
+    PowerMockito.mockStatic(File.class);
+    PowerMockito.when(File.createTempFile(Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(mFile);
     String errorMessage = "protocol doesn't support output";
     PowerMockito.whenNew(FileOutputStream.class).withArguments(mFile)
             .thenThrow(new IOException(errorMessage));
@@ -153,7 +155,9 @@ public class OBSOutputStreamTest {
   @Test
   @PrepareForTest(OBSOutputStream.class)
   public void testCloseSuccess() throws Exception {
-    PowerMockito.whenNew(File.class).withArguments(Mockito.anyString()).thenReturn(mFile);
+    PowerMockito.mockStatic(File.class);
+    PowerMockito.when(File.createTempFile(Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(mFile);
     FileOutputStream outputStream = PowerMockito.mock(FileOutputStream.class);
     PowerMockito.whenNew(FileOutputStream.class).withArguments(mFile).thenReturn(outputStream);
     FileInputStream inputStream = PowerMockito.mock(FileInputStream.class);


### PR DESCRIPTION
After configuring ~/.m2/settings.xml according to https://github.com/jcaddel/maven-s3-wagon/wiki/Usage, `mvn deploy` will build and upload the jars to S3 bucket `maven.alluxio`.