### PR TITLE
[ALLUXIO-3283] local under file system storage, implemented by sftp sub-protocol of ssh

### DIFF
--- a/underfs/ssh/README.md
+++ b/underfs/ssh/README.md
@@ -1,0 +1,21 @@
+## SSH Under Storage
+
+Alluxio under storage implementation for accessing local file system using the `ssh://` scheme. This module is built using the sshj library, which is implemented by SFTP, a subprotocol of SSH.
+
+### Build
+
+```bash
+mvn package
+```
+
+### Run Integration Tests
+
+```bash
+mvn test -DtestSshUFS=ssh://<host-name>/<folder> -Dssh.username=<username> -Dssh.password=<password>
+```
+
+### Mount
+
+```bash
+./bin/alluxio fs mount --option ssh.username=<username> --option ssh.password=<password> /mnt/ssh ssh://<host-name>/<folder>
+```

--- a/underfs/ssh/pom.xml
+++ b/underfs/ssh/pom.xml
@@ -1,0 +1,195 @@
+<!--
+
+    The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+    (the "License"). You may not use this work except in compliance with the License, which is
+    available at www.apache.org/licenses/LICENSE-2.0
+
+    This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, as more fully set forth in the License.
+
+    See the NOTICE file distributed with this work for information regarding copyright ownership.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.alluxio</groupId>
+  <artifactId>alluxio-underfs-ssh</artifactId>
+  <version>1.8.0-SNAPSHOT</version>
+  <name>Alluxio Under File System - SSH FS</name>
+  <description>SSH FS Under File System implementation</description>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <!-- This should be at top, it makes maven try the central repo first and then others and hence faster dep resolution -->
+      <name>Maven Repository</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>apache-repo</id>
+      <name>Apache Repository</name>
+      <url>https://repository.apache.org/content/repositories/releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <properties>
+    <alluxio.version>1.8.0</alluxio.version>
+    <build.path>build</build.path>
+    <java.version>1.8</java.version>
+    <junit.version>4.12</junit.version>
+    <sshj.version>0.23.0</sshj.version>
+    <cglib.version>3.2.5</cglib.version>
+    <mockito.version>1.10.8</mockito.version>
+    <powermock.version>1.6.1</powermock.version>
+  </properties>
+
+  <dependencies>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>com.hierynomus</groupId>
+      <artifactId>sshj</artifactId>
+      <version>${sshj.version}</version>
+      <exclusions>
+        <!-- Excluded to avoid implementation conflict with slf4j -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>${cglib.version}</version>
+    </dependency>
+
+    <!-- Internal dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${alluxio.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Core Alluxio test dependencies -->
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <version>${alluxio.version}</version>
+    </dependency>
+
+    <!-- External test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-classloading-xstream</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-rule</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <encoding>UTF-8</encoding>
+          <maxmem>1024m</maxmem>
+          <compilerArgs>
+            <arg>-Xlint:none</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/underfs/ssh/src/main/java/alluxio/underfs/ssh/RemoteIdInfo.java
+++ b/underfs/ssh/src/main/java/alluxio/underfs/ssh/RemoteIdInfo.java
@@ -1,0 +1,154 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.Configuration;
+
+import com.google.common.io.Closer;
+import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.SFTPClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A class used to map remote user or group id to name.
+ */
+@ThreadSafe
+public class RemoteIdInfo {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteIdInfo.class);
+  private static final int MIN_REFRESH_INTERVAL = 5 * 60 * 1000;
+
+  private SFTPClient mSftpClient;
+  private String mRemotePath;
+  private long mLastRefreshTime = 0;
+
+  // This class is designed to be thread safe, and these maps are instantiated to
+  // be normal map. So the "modify" methods of maps should not be called.
+  private Map<Integer, String> mId2Name = new HashMap<>();
+  private Map<String, Integer> mName2Uid = new HashMap<>();
+
+  /**
+   * Construct a new {@link RemoteIdInfo}.
+   *
+   * @param sftpClient the client used to fetch remote file
+   * @param remotePath for which path to fetch
+   */
+  public RemoteIdInfo(SFTPClient sftpClient, String remotePath) {
+    mSftpClient = sftpClient;
+    mRemotePath = remotePath;
+  }
+
+  /**
+   * Guess the user name from id.
+   *
+   * @param id the id of the user
+   * @return the user name
+   */
+  public String guessName(Integer id) {
+    // This class is designed to be thread safe, but no lock operations such as
+    // synchronized used. So statements such as mId2Name.containsKey(id) ? mId2Name.get(id) : xx
+    // is not thread safe. As content of mId2Name never updated, and only modified by assignment
+    // operation, so it's thread safe of assigning the value to a temporary variable.
+    Map<Integer, String> map = mId2Name;
+    if (!map.containsKey(id)) {
+      tryRefresh();
+      map = mId2Name;
+    }
+    return map.containsKey(id) ? map.get(id) : id.toString();
+  }
+
+  /**
+   * Get the user id from its name.
+   *
+   * @param name the user name
+   * @return the id or null if invalid name
+   */
+  public Integer getId(String name) {
+    try {
+      return getIdFromName(name, mName2Uid);
+    } catch (NumberFormatException e) {
+      tryRefresh();
+      try {
+        return getIdFromName(name, mName2Uid);
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Try to refresh when the interval between last refresh time is larger then
+   * the configured threshold
+   */
+  public void tryRefresh() {
+    long curTime = System.currentTimeMillis();
+    long interval = Configuration.getMs(SshUFSPropertyKey.SSH_IDMAP_REFRESH_INTERVAL);
+    if (curTime - mLastRefreshTime < interval) {
+      return;
+    }
+    mId2Name = getIdNameMap(mRemotePath);
+    mName2Uid = mId2Name.entrySet().stream().collect(
+        Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    mLastRefreshTime = curTime;
+  }
+
+  // If member field mName2Uid used instead of second argument directly
+  // this method will not be thread safe, because mName2Uid may be
+  // assigned to another map after containsKey method called.
+  private Integer getIdFromName(String name, Map<String, Integer> map)
+      throws NumberFormatException {
+    if (map.containsKey(name)) {
+      return map.get(name);
+    }
+    return Integer.parseInt(name);
+  }
+
+  private Map<Integer, String> getIdNameMap(String path) {
+    Map<Integer, String> ret = new HashMap<>();
+    try (Closer closer = Closer.create()) {
+      RemoteFile file = mSftpClient.open(path);
+      closer.register(file);
+      InputStream stream = file.new RemoteFileInputStream();
+      closer.register(stream);
+      BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+      closer.register(reader);
+
+      // Currently, only these two files: /etc/passwd and /etc/group is supported,
+      // and the format of each line like this:
+      // work:x:500:500::/home/work:/bin/bash
+      // or
+      // work:x:500:
+      // which is split by colon, only first and third part are used
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] splits = line.split(":", 4);
+        if (splits.length < 3) {
+          continue;
+        }
+        ret.put(Integer.valueOf(splits[2]), splits[0]);
+      }
+    } catch (IOException e) {
+      LOG.info("get id map file failed: " + path, e);
+    }
+    return ret;
+  }
+}

--- a/underfs/ssh/src/main/java/alluxio/underfs/ssh/SftpFactory.java
+++ b/underfs/ssh/src/main/java/alluxio/underfs/ssh/SftpFactory.java
@@ -1,0 +1,354 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.collections.ConcurrentHashSet;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.ThreadFactoryUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.io.Closer;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.sftp.SFTPEngine;
+import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The factory used to generate sftp client instance.
+ */
+public class SftpFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(SftpFactory.class);
+  private static final String CLOSE_METHOD = "close";
+  private static final String SSH_GUEST_USER = "guest";
+  private static final int STREAM_CACHE_RW_NUM = 8;
+  private static final long MAX_IDLE_INTERVAL
+      = Configuration.getMs(SshUFSPropertyKey.SSH_MAX_IDLE_INTERVAL);
+
+  private static Set<SftpContainer> sLiveContainers = new ConcurrentHashSet<>();
+  private static ScheduledExecutorService sExecutor = Executors.newSingleThreadScheduledExecutor(
+      ThreadFactoryUtils.build("SftpFactory-close-idle-sftp-%d", true));
+
+  /**
+   * Create a sftp client.
+   * The returned instance is a proxy of SFTPClient in order to support auto connection
+   * and release feature. The ssh and sftp will be connected if the member method called first time,
+   * and the sftp and ssh will be closed if the instance is not used for a while.
+   *
+   * @param uri the {@link AlluxioURI} for this UFS
+   * @param ufsConf UFS configuration
+   * @return the generated instance
+   * @throws IOException
+   */
+  public static SFTPClient createSftpClient(AlluxioURI uri, UnderFileSystemConfiguration ufsConf)
+      throws IOException {
+    SftpContainer container = new SftpContainer(uri, ufsConf);
+    sLiveContainers.add(container);
+    return container.getSftpClientProxy();
+  }
+
+  /**
+   * Create a remote file to an input stream, which will close the RemoteFile instance
+   * in close method. And the remote file should not be accessed after transformation.
+   *
+   * @param remoteFile the remote file
+   * @param offset the offset
+   * @return the input stream
+   * @throws IOException
+   */
+  public static InputStream createInputStream(RemoteFile remoteFile, long offset)
+      throws IOException {
+    Enhancer enhancer = new Enhancer();
+    enhancer.setCallback(new CloseInterceptor(remoteFile));
+    enhancer.setSuperclass(RemoteFile.ReadAheadRemoteFileInputStream.class);
+
+    // The returned instance is a proxy of remoteFile.new ReadAheadRemoteFileInputStream(int, long),
+    // and the proxy behavior is to close the remoteFile in close method
+    return (InputStream) enhancer.create(
+        new Class[] {RemoteFile.class, int.class, long.class},
+        new Object[] {remoteFile, STREAM_CACHE_RW_NUM, offset});
+  }
+
+  /**
+   * Create a remote file to an output stream, which will close the RemoteFile instance
+   * in close method. And the remote file should not be accessed after transformation.
+   *
+   * @param remoteFile the remote file
+   * @return the output stream
+   * @throws IOException
+   */
+  public static OutputStream createOutputStream(RemoteFile remoteFile)
+      throws IOException {
+    Enhancer enhancer = new Enhancer();
+    enhancer.setCallback(new CloseInterceptor(remoteFile));
+    enhancer.setSuperclass(RemoteFile.RemoteFileOutputStream.class);
+
+    // The returned instance is a proxy of remoteFile.new RemoteFileOutputStream(long, int),
+    // and the proxy behavior is to close the remoteFile in close method
+    return (OutputStream) enhancer.create(
+        new Class[] {RemoteFile.class, long.class, int.class},
+        new Object[] {remoteFile, 0, STREAM_CACHE_RW_NUM});
+  }
+
+  static {
+    long delay =  MAX_IDLE_INTERVAL / 2;
+    sExecutor.scheduleAtFixedRate(() -> scanIdle(), delay, delay, TimeUnit.MILLISECONDS);
+  }
+
+  protected static void scanIdle() {
+    sLiveContainers.stream().forEach(container -> container.closeIfIdle());
+  }
+
+  /**
+   * The container class of SFTP, which used to record the parameters used to
+   * build SFTP connection, and maintain the connection instance.
+   */
+  private static class SftpContainer {
+    private SSHClient mSshClient;
+    private SFTPClient mSftpClient;
+    private SFTPClient mSftpClientProxy;
+
+    private String mUsername;
+    private String mPassword;
+    private String mHost;
+    private int mPort;
+
+    private long mLastActiveTime = 0;
+    private Set<Object> mClientReferers = new HashSet<>();
+
+    public SftpContainer(AlluxioURI uri, UnderFileSystemConfiguration ufsConf) {
+      mUsername = SSH_GUEST_USER;
+      if (ufsConf.containsKey(SshUFSPropertyKey.SSH_USERNAME)) {
+        mUsername = ufsConf.getValue(SshUFSPropertyKey.SSH_USERNAME);
+      }
+      mPassword = "";
+      if (ufsConf.containsKey(SshUFSPropertyKey.SSH_PASSWORD)) {
+        mPassword = ufsConf.getValue(SshUFSPropertyKey.SSH_PASSWORD);
+      }
+
+      mHost = uri.getHost();
+      mPort = -1;
+      if (uri.getPort() > 0) {
+        mPort = uri.getPort();
+      }
+    }
+
+    /**
+     * It is supposed that the sftp client can be connected when methods called and closed
+     * after a while automatically. The best implementation is to proxy the client, connect
+     * before each call of method, and close the connection after a certain time.
+     *
+     * @return the proxy client
+     * @throws IOException
+     */
+    public SFTPClient getSftpClientProxy() throws IOException {
+      SFTPClient client = connectSftp();
+
+      Enhancer enhancer = new Enhancer();
+      enhancer.setCallback(new SftpClientInterceptor());
+      enhancer.setSuperclass(SFTPClient.class);
+      mSftpClientProxy = (SFTPClient) enhancer.create(
+          new Class[]{SFTPEngine.class}, new Object[]{client.getSFTPEngine()});
+
+      return mSftpClientProxy;
+    }
+
+    private synchronized SFTPClient connectSftp() throws IOException {
+      if (mLastActiveTime > 0) {
+        mLastActiveTime = System.currentTimeMillis();
+        return mSftpClient;
+      }
+
+      LOG.info("will connect sftp to host: " + mHost);
+      mSshClient = new SSHClient();
+      // do not verify the public key of remote
+      mSshClient.addHostKeyVerifier(new PromiscuousVerifier());
+      if (mPort > 0) {
+        mSshClient.connect(mHost, mPort);
+      } else {
+        mSshClient.connect(mHost);
+      }
+
+      if (Strings.isNullOrEmpty(mPassword)) {
+        mSshClient.authPublickey(mUsername);
+      } else {
+        mSshClient.authPassword(mUsername, mPassword);
+      }
+      mSftpClient = mSshClient.newSFTPClient();
+
+      mClientReferers.clear();
+      mLastActiveTime = System.currentTimeMillis();
+      return mSftpClient;
+    }
+
+    private void closeIfIdle() {
+      Closer closer;
+      long curTime = System.currentTimeMillis();
+      synchronized (this) {
+        if (mLastActiveTime == 0 // closed
+            || !mClientReferers.isEmpty() || curTime - mLastActiveTime < MAX_IDLE_INTERVAL) {
+          return;
+        }
+        closer = Closer.create();
+        closer.register(mSshClient);
+        closer.register(mSftpClient);
+        mSshClient = null;
+        mSftpClient = null;
+        mLastActiveTime = 0;
+      }
+
+      LOG.info("will close sftp connect to host: " + mHost);
+      try {
+        closer.close();
+      } catch (IOException e) {
+        LOG.error("close ssh connection failed of host: " + mHost, e);
+      }
+    }
+
+    private synchronized void incReference(Object refer) {
+      Preconditions.checkArgument(mSftpClient != null,
+          mHost + " sftp not connected or connection closed, maybe idle interval is too small");
+      mClientReferers.add(refer);
+      mLastActiveTime = System.currentTimeMillis();
+    }
+
+    private synchronized boolean decReference(Object refer) {
+      if (!mClientReferers.contains(refer)) {
+        return false;
+      }
+      mClientReferers.remove(refer);
+      mLastActiveTime = System.currentTimeMillis();
+      return true;
+    }
+
+    private RemoteFile proxyRemoteFile(RemoteFile original, SFTPClient sftpClient) {
+      Enhancer enhancer = new Enhancer();
+      enhancer.setCallback(new RemoteFileInterceptor(original));
+      enhancer.setSuperclass(RemoteFile.class);
+      return (RemoteFile) enhancer.create(
+          new Class[]{SFTPEngine.class, String.class, byte[].class},
+          new Object[]{sftpClient.getSFTPEngine(), null, null});
+    }
+
+    /**
+     * Sftp will be connected for the first time.
+     * And the last access time is updated, a reference of current client
+     * is recorded if getting a closeable instance, these two conditions
+     * are used to determine whether the connection should be closed
+     * after a while.
+     */
+    private class SftpClientInterceptor implements MethodInterceptor {
+      @Override
+      public Object intercept(
+          Object object,
+          Method method,
+          Object[] objects,
+          MethodProxy methodProxy) throws Throwable {
+
+        SFTPClient sftpClient = connectSftp();
+
+        Object ret = methodProxy.invoke(sftpClient, objects);
+        if (ret == null || method.getName().startsWith("get")) {
+          return ret;
+        } else if (RemoteFile.class.isAssignableFrom(ret.getClass())) {
+          incReference(ret);
+          return proxyRemoteFile((net.schmizz.sshj.sftp.RemoteFile) ret, sftpClient);
+        } else if (AutoCloseable.class.isAssignableFrom(ret.getClass())) {
+          throw new RuntimeException("Not supported method by the proxy: " + method);
+        }
+        return ret;
+      }
+    }
+
+    /**
+     * The reference of sftp client is released in close method,
+     * so the client can be detected to be idle and then closed.
+     */
+    private class RemoteFileInterceptor implements MethodInterceptor {
+      private RemoteFile mOriginalRemoteFile;
+
+      /**
+       * Constructs an interceptor.
+       *
+       * @param originalRemoteFile the original instance
+       */
+      public RemoteFileInterceptor(RemoteFile originalRemoteFile) {
+        mOriginalRemoteFile = originalRemoteFile;
+      }
+
+      @Override
+      public Object intercept(
+          Object object,
+          Method method,
+          Object[] objects,
+          MethodProxy methodProxy) throws Throwable {
+        if (!CLOSE_METHOD.equals(method.getName()) || method.getParameterCount() != 0) {
+          return methodProxy.invoke(mOriginalRemoteFile, objects);
+        }
+        if (decReference(mOriginalRemoteFile)) {
+          // the close method of RemoteFile is not reenterable
+          mOriginalRemoteFile.close();
+        }
+        return null;
+      }
+    }
+  }
+
+  /**
+   * This class is used to generated a integrated stream, to close
+   * the corresponding RemoteFile instance in the close method.
+   */
+  private static class CloseInterceptor implements MethodInterceptor {
+    private AutoCloseable mCloseable;
+
+    /**
+     * Constructs a new {@link CloseInterceptor}.
+     *
+     * @param closeable The closeable object used in close method
+     */
+    public CloseInterceptor(AutoCloseable closeable) {
+      mCloseable = closeable;
+    }
+
+    @Override
+    public Object intercept(Object object, Method method, Object[] objects, MethodProxy methodProxy)
+        throws Throwable {
+      if (!CLOSE_METHOD.equals(method.getName()) || method.getParameterCount() != 0) {
+        return methodProxy.invokeSuper(object, objects);
+      }
+
+      try {
+        return methodProxy.invokeSuper(object, objects);
+      } finally {
+        mCloseable.close();
+      }
+    }
+  }
+}

--- a/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUFSPropertyKey.java
+++ b/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUFSPropertyKey.java
@@ -1,0 +1,62 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.PropertyKey;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * SSH under file system property keys.
+ */
+@ThreadSafe
+public class SshUFSPropertyKey {
+  public static final PropertyKey SSH_USERNAME =
+      new PropertyKey.Builder(Name.SSH_USERNAME)
+          .setDescription("User name when login with ssh.")
+          .build();
+  public static final PropertyKey SSH_PASSWORD =
+      new PropertyKey.Builder(Name.SSH_PASSWORD)
+          .setDescription("Password when login with ssh.")
+          .build();
+  public static final PropertyKey SSH_PWDFILE_PATH =
+      new PropertyKey.Builder(Name.SSH_PWDFILE_PATH)
+          .setDefaultValue("/etc/passwd")
+          .setDescription("Password file used when mapping user id to name.")
+          .build();
+  public static final PropertyKey SSH_GROUPFILE_PATH =
+      new PropertyKey.Builder(Name.SSH_GROUPFILE_PATH)
+          .setDefaultValue("/etc/group")
+          .setDescription("Group file used when mapping user id to name.")
+          .build();
+  public static final PropertyKey SSH_IDMAP_REFRESH_INTERVAL =
+      new PropertyKey.Builder(Name.SSH_IDMAP_REFRESH_INTERVAL)
+          .setDefaultValue("5min")
+          .setDescription("Group file used when mapping user id to name.")
+          .build();
+  public static final PropertyKey SSH_MAX_IDLE_INTERVAL =
+      new PropertyKey.Builder(Name.SSH_MAX_IDLE_INTERVAL)
+          .setDefaultValue("30min")
+          .setDescription("Sftp connection will be closed after idled for the interval, " +
+              "must be larger than 1 min")
+          .build();
+
+  @ThreadSafe
+  public static final class Name {
+    public static final String SSH_USERNAME = "ssh.username";
+    public static final String SSH_PASSWORD = "ssh.password";
+    public static final String SSH_PWDFILE_PATH = "ssh.pwdfile.path";
+    public static final String SSH_GROUPFILE_PATH = "ssh.groupfile.path";
+    public static final String SSH_IDMAP_REFRESH_INTERVAL = "ssh.idmap.refresh.interval";
+    public static final String SSH_MAX_IDLE_INTERVAL = "ssh.max.idle.interval";
+  }
+}

--- a/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUnderFileSystem.java
+++ b/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUnderFileSystem.java
@@ -1,0 +1,396 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.PropertyKey;
+import alluxio.exception.ExceptionMessage;
+import alluxio.underfs.AtomicFileOutputStream;
+import alluxio.underfs.AtomicFileOutputStreamCallback;
+import alluxio.underfs.BaseUnderFileSystem;
+import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.FileLocationOptions;
+import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
+import alluxio.util.UnderFileSystemUtils;
+
+import net.schmizz.sshj.sftp.FileAttributes;
+import net.schmizz.sshj.sftp.FileMode;
+import net.schmizz.sshj.sftp.OpenMode;
+import net.schmizz.sshj.sftp.PathComponents;
+import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+import net.schmizz.sshj.sftp.Response;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.sftp.SFTPEngine;
+import net.schmizz.sshj.sftp.SFTPException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SSH FS {@link UnderFileSystem} implementation based on the jsch-nio library.
+ */
+public class SshUnderFileSystem extends BaseUnderFileSystem
+    implements AtomicFileOutputStreamCallback{
+  private static final Logger LOG = LoggerFactory.getLogger(SshUnderFileSystem.class);
+
+  public static final String SCHEME = "ssh://";
+
+  private SFTPClient mSftpClient;
+  private RemoteIdInfo mRemoteUserIdInfo;
+  private RemoteIdInfo mRemoteGroupIdInfo;
+  private String mHost;
+
+  /**
+   * Constructs a new {@link SshUnderFileSystem}.
+   *
+   * @param uri the {@link AlluxioURI} for this UFS
+   * @param ufsConf UFS configuration
+   */
+  public SshUnderFileSystem(AlluxioURI uri, UnderFileSystemConfiguration ufsConf) {
+    super(uri, ufsConf);
+    mHost = uri.getHost();
+    try {
+      mSftpClient = SftpFactory.createSftpClient(uri, ufsConf);
+    } catch (IOException e) {
+      throw new RuntimeException("SSH login failed", e);
+    }
+    mRemoteUserIdInfo = new RemoteIdInfo(
+        mSftpClient, Configuration.get(SshUFSPropertyKey.SSH_PWDFILE_PATH));
+    mRemoteGroupIdInfo = new RemoteIdInfo(
+        mSftpClient, Configuration.get(SshUFSPropertyKey.SSH_GROUPFILE_PATH));
+  }
+
+  @Override
+  public String getUnderFSType() {
+    return "ssh";
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public OutputStream create(String path, CreateOptions options) throws IOException {
+    path = getRemotePath(path);
+    if (!options.isEnsureAtomic()) {
+      return createDirect(path, options);
+    }
+    return new AtomicFileOutputStream(path, this, options);
+  }
+
+  @Override
+  public OutputStream createDirect(String path, CreateOptions options) throws IOException {
+    path = getRemotePath(path);
+    if (options.getCreateParent()) {
+      File parent = new File(path).getParentFile();
+      MkdirsOptions mkdirOptions = MkdirsOptions.defaults()
+          .setCreateParent(true)
+          .setOwner(options.getOwner())
+          .setGroup(options.getGroup())
+          .setMode(MkdirsOptions.defaults().getMode());
+      if (parent != null && !mkdirs(parent.getPath(), mkdirOptions)) {
+        throw new IOException(ExceptionMessage.PARENT_CREATION_FAILED.getMessage(path));
+      }
+    }
+    Set<OpenMode> modes = EnumSet.of(OpenMode.WRITE, OpenMode.CREAT, OpenMode.TRUNC);
+    FileAttributes.Builder builder = new FileAttributes.Builder();
+    builder.withPermissions(options.getMode().toShort());
+    Integer uid = mRemoteUserIdInfo.getId(options.getOwner());
+    Integer gid = mRemoteGroupIdInfo.getId(options.getGroup());
+    if (null != uid && null != gid) {
+      LOG.info("will create stream with default user group");
+      builder.withUIDGID(uid, gid);
+    }
+    RemoteFile remoteFile = mSftpClient.open(path, modes, builder.build());
+    return SftpFactory.createOutputStream(remoteFile);
+  }
+
+  @Override
+  public boolean deleteDirectory(String path, DeleteOptions options) throws IOException {
+    path = getRemotePath(path);
+    if (!isDirectory(path)) {
+      return false;
+    }
+    if (!options.isRecursive()) {
+      mSftpClient.rmdir(path);
+    } else {
+      deleteDirectoryRecursive(path);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean deleteFile(String path) throws IOException {
+    path = getRemotePath(path);
+    mSftpClient.rm(path);
+    return true;
+  }
+
+  @Override
+  public boolean exists(String path) throws IOException {
+    path = getRemotePath(path);
+    return null != mSftpClient.statExistence(path);
+  }
+
+  @Override
+  public long getBlockSizeByte(String path) throws IOException {
+    return Configuration.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+  }
+
+  @Override
+  public UfsDirectoryStatus getDirectoryStatus(String path) throws IOException {
+    path = getRemotePath(path);
+    FileAttributes attributes = mSftpClient.stat(path);
+    return generateDirectoryStatus(path, attributes);
+  }
+
+  @Override
+  public List<String> getFileLocations(String path) throws IOException {
+    return Arrays.asList(mHost);
+  }
+
+  @Override
+  public List<String> getFileLocations(String path, FileLocationOptions options)
+      throws IOException {
+    return getFileLocations(path);
+  }
+
+  @Override
+  public UfsFileStatus getFileStatus(String path) throws IOException {
+    path = getRemotePath(path);
+    FileAttributes attributes = mSftpClient.stat(path);
+    return generateFileStatus(path, attributes);
+  }
+
+  @Override
+  public long getSpace(String path, SpaceType type) throws IOException {
+    // we do not support getting space of this fs
+    return -1;
+  }
+
+  @Override
+  public UfsStatus getStatus(String path) throws IOException {
+    if (isFile(path)) {
+      return getFileStatus(path);
+    }
+    return getDirectoryStatus(path);
+  }
+
+  @Override
+  public boolean isDirectory(String path) throws IOException {
+    path = getRemotePath(path);
+    FileAttributes attributes = mSftpClient.statExistence(path);
+    return null != attributes && FileMode.Type.DIRECTORY.equals(attributes.getType());
+  }
+
+  @Override
+  public boolean isFile(String path) throws IOException {
+    path = getRemotePath(path);
+    FileAttributes attributes = mSftpClient.statExistence(path);
+    return null != attributes && FileMode.Type.REGULAR.equals(attributes.getType());
+  }
+
+  @Override
+  public UfsStatus[] listStatus(String path) throws IOException {
+    path = getRemotePath(path);
+    List<RemoteResourceInfo> resourceInfos = null;
+    try {
+      resourceInfos = mSftpClient.ls(path);
+    } catch (SFTPException e) {
+      if (e.getStatusCode() != Response.StatusCode.NO_SUCH_FILE) {
+        throw e;
+      }
+    }
+    if (null == resourceInfos || (
+        resourceInfos.size() == 1 && resourceInfos.get(0).getPath().equals(path))) {
+      return null;
+    }
+
+    int i = 0;
+    UfsStatus[] ufsStatus = new UfsStatus[resourceInfos.size()];
+    for (RemoteResourceInfo info : resourceInfos) {
+      if (!info.isDirectory()) {
+        ufsStatus[i++] = generateFileStatus(info.getName(), info.getAttributes());
+      } else {
+        ufsStatus[i++] = generateDirectoryStatus(info.getName(), info.getAttributes());
+      }
+    }
+    return ufsStatus;
+  }
+
+  @Override
+  public boolean mkdirs(String path, MkdirsOptions options) throws IOException {
+    path = getRemotePath(path);
+    SFTPEngine engine = mSftpClient.getSFTPEngine();
+    final Deque<String> dirsToMake = new LinkedList<>();
+    // generate the directories to make
+    if (!options.getCreateParent()) {
+      dirsToMake.push(path);
+    } else {
+      for (PathComponents current = engine.getPathHelper().getComponents(path);;
+           current = engine.getPathHelper().getComponents(current.getParent())) {
+        final FileAttributes attrs = mSftpClient.statExistence(current.getPath());
+        if (attrs == null) {
+          dirsToMake.push(current.getPath());
+        } else if (attrs.getType() != FileMode.Type.DIRECTORY) {
+          LOG.warn("Failed to make path who goes through a file: " + current.getPath());
+          return false;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // really make operations
+    FileAttributes.Builder builder = new FileAttributes.Builder();
+    FileAttributes modeAttributes = builder.withPermissions(options.getMode().toShort()).build();
+    while (!dirsToMake.isEmpty()) {
+      path = dirsToMake.pop();
+      try {
+        engine.makeDir(path, modeAttributes);
+      } catch (IOException e) {
+        LOG.info("failed to mkdir {} by ssh", path);
+        return false;
+      }
+      try {
+        setOwner(path, options.getOwner(), options.getGroup());
+      } catch (IOException e) {
+        LOG.warn("Failed to update the ufs dir ownership, default values will be used: {}",
+            e.getMessage());
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public InputStream open(String path, OpenOptions options) throws IOException {
+    path = getRemotePath(path);
+    RemoteFile remoteFile = mSftpClient.open(path);
+    return SftpFactory.createInputStream(remoteFile, options.getOffset());
+  }
+
+  @Override
+  public boolean renameDirectory(String src, String dst) throws IOException {
+    if (!isDirectory(src)) {
+      LOG.warn("Unable to rename {} to {} because source does not exist or is a file.", src, dst);
+      return false;
+    }
+    rename(src, dst);
+    return true;
+  }
+
+  @Override
+  public boolean renameFile(String src, String dst) throws IOException {
+    if (!isFile(src)) {
+      LOG.warn("Unable to rename {} to {} because source does not exist or is a file.", src, dst);
+      return false;
+    }
+    rename(src, dst);
+    return true;
+  }
+
+  @Override
+  public void setOwner(String path, String owner, String group) throws IOException {
+    path = getRemotePath(path);
+    Integer uid = mRemoteUserIdInfo.getId(owner);
+    Integer gid = mRemoteGroupIdInfo.getId(group);
+    if (null == uid || null == gid) {
+      throw new IOException("invalid user or group");
+    }
+    FileAttributes.Builder builder = new FileAttributes.Builder();
+    mSftpClient.setattr(path, builder.withUIDGID(uid, gid).build());
+  }
+
+  @Override
+  public void setMode(String path, short mode) throws IOException {
+    path = getRemotePath(path);
+    mSftpClient.chmod(path, mode);
+  }
+
+  @Override
+  public void connectFromMaster(String hostname) throws IOException {
+  }
+
+  @Override
+  public void connectFromWorker(String hostname) throws IOException {
+  }
+
+  @Override
+  public boolean supportsFlush() {
+    return true;
+  }
+
+  private String getRemotePath(String path) {
+    AlluxioURI uri = new AlluxioURI(path);
+    return uri.getPath();
+  }
+
+  private void deleteDirectoryRecursive(String path) throws IOException {
+    List<RemoteResourceInfo> resourceInfos = mSftpClient.ls(path);
+    for (RemoteResourceInfo info : resourceInfos) {
+      if (info.isDirectory()) {
+        deleteDirectoryRecursive(info.getPath());
+      } else {
+        mSftpClient.rm(info.getPath());
+      }
+    }
+    mSftpClient.rmdir(path);
+  }
+
+  private void rename(String src, String dst) throws IOException {
+    String srcPath = getRemotePath(src);
+    String dstPath = getRemotePath(dst);
+    mSftpClient.rename(srcPath, dstPath);
+  }
+
+  private UfsFileStatus generateFileStatus(String path, FileAttributes attributes) {
+    long modifyTime = TimeUnit.MILLISECONDS.convert(attributes.getMtime(), TimeUnit.SECONDS);
+    long length = attributes.getSize();
+    String contentHash = UnderFileSystemUtils.approximateContentHash(length, modifyTime);
+    return new UfsFileStatus(
+        path,
+        contentHash,
+        length,
+        modifyTime,
+        mRemoteUserIdInfo.guessName(attributes.getUID()),
+        mRemoteGroupIdInfo.guessName(attributes.getGID()),
+        (short) attributes.getMode().getMask());
+  }
+
+  private UfsDirectoryStatus generateDirectoryStatus(String path, FileAttributes attributes) {
+    return new UfsDirectoryStatus(
+        path,
+        mRemoteUserIdInfo.guessName(attributes.getUID()),
+        mRemoteGroupIdInfo.guessName(attributes.getGID()),
+        (short) attributes.getMode().getMask());
+  }
+}

--- a/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUnderFileSystemFactory.java
+++ b/underfs/ssh/src/main/java/alluxio/underfs/ssh/SshUnderFileSystemFactory.java
@@ -1,0 +1,43 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.AlluxioURI;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemFactory;
+
+import com.google.common.base.Preconditions;
+
+import javax.annotation.Nullable;
+
+/**
+ * Factory for creating {@link SshUnderFileSystem}.
+ */
+public class SshUnderFileSystemFactory implements UnderFileSystemFactory {
+
+  /**
+   * Constructs a new {@link SshUnderFileSystemFactory}.
+   */
+  public SshUnderFileSystemFactory() {}
+
+  @Override
+  public UnderFileSystem create(String path, @Nullable UnderFileSystemConfiguration conf) {
+    Preconditions.checkNotNull(path, "path may not be null");
+    return new SshUnderFileSystem(new AlluxioURI(path), conf);
+  }
+
+  @Override
+  public boolean supportsPath(String path) {
+    return path != null && path.startsWith(SshUnderFileSystem.SCHEME);
+  }
+}

--- a/underfs/ssh/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
+++ b/underfs/ssh/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
@@ -1,0 +1,12 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.underfs.ssh.SshUnderFileSystemFactory

--- a/underfs/ssh/src/test/java/alluxio/underfs/ssh/RemoteIdInfoTest.java
+++ b/underfs/ssh/src/test/java/alluxio/underfs/ssh/RemoteIdInfoTest.java
@@ -1,0 +1,90 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.Configuration;
+
+import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.SFTPClient;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Unit tests for {@link RemoteIdInfo}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RemoteIdInfo.class)
+public class RemoteIdInfoTest {
+
+  @Mock
+  private BufferedReader mReaderMock;
+
+  private RemoteIdInfo mRemoteIdInfo;
+
+  @Before
+  public void setup() throws Exception {
+    RemoteFile remoteFileMock = Mockito.mock(RemoteFile.class);
+    SFTPClient sftpClient = Mockito.mock(SFTPClient.class);
+    Mockito.when(sftpClient.open(Matchers.anyString())).thenReturn(remoteFileMock);
+    PowerMockito
+        .whenNew(InputStreamReader.class)
+        .withAnyArguments()
+        .thenReturn(Mockito.mock(InputStreamReader.class));
+
+    PowerMockito.whenNew(BufferedReader.class).withAnyArguments().thenReturn(mReaderMock);
+
+    mRemoteIdInfo = new RemoteIdInfo(
+        sftpClient, Configuration.get(SshUFSPropertyKey.SSH_GROUPFILE_PATH));
+  }
+
+  @Test
+  public void testGuessName() throws IOException {
+    Mockito.when(mReaderMock.readLine()).thenReturn("user:x:1:1:", null);
+
+    Assert.assertEquals("user", mRemoteIdInfo.guessName(1));
+    Assert.assertEquals("2", mRemoteIdInfo.guessName(2));
+  }
+
+  @Test
+  public void testGetId() throws IOException {
+    Mockito.when(mReaderMock.readLine()).thenReturn("user:x:1:1:", null);
+
+    Assert.assertEquals(Integer.valueOf(1), mRemoteIdInfo.getId("user"));
+    Assert.assertEquals(Integer.valueOf(2), mRemoteIdInfo.getId("2"));
+    Assert.assertNull(mRemoteIdInfo.getId("nonexist"));
+  }
+
+  @Test
+  public void testRefresh() throws IOException {
+    Mockito.when(mReaderMock.readLine()).thenReturn(null, "user:x:1:1:", null);
+
+    Assert.assertNull(mRemoteIdInfo.getId("user"));
+
+    long curTime = System.currentTimeMillis();
+    PowerMockito.mockStatic(System.class);
+    PowerMockito.when(System.currentTimeMillis()).thenReturn(curTime + 24 * 60 * 60 * 1000);
+
+    Assert.assertEquals(Integer.valueOf(1), mRemoteIdInfo.getId("user"));
+  }
+}

--- a/underfs/ssh/src/test/java/alluxio/underfs/ssh/SftpFactoryTest.java
+++ b/underfs/ssh/src/test/java/alluxio/underfs/ssh/SftpFactoryTest.java
@@ -1,0 +1,126 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.underfs.UnderFileSystemConfiguration;
+
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.sftp.RemoteFile;
+import net.schmizz.sshj.sftp.SFTPClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link SftpFactory}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SftpFactory.class)
+public class SftpFactoryTest {
+  private SSHClient mSshClientMock;
+  private SFTPClient mSftpClientMock;
+  private UnderFileSystemConfiguration mUfsConf;
+
+  @Before
+  public void setup() throws Exception {
+    mSshClientMock = Mockito.mock(SSHClient.class);
+    mSftpClientMock = Mockito.mock(SFTPClient.class, Mockito.RETURNS_DEEP_STUBS);
+    mUfsConf = UnderFileSystemConfiguration.defaults();
+
+    PowerMockito.whenNew(SSHClient.class).withAnyArguments().thenReturn(mSshClientMock);
+    Mockito.when(mSshClientMock.newSFTPClient()).thenReturn(mSftpClientMock);
+  }
+
+  @Test
+  public void testConnectParam() throws Exception {
+    AlluxioURI uri = new AlluxioURI("pfs", "baidu.com", "/path");
+    SftpFactory.createSftpClient(uri, mUfsConf);
+
+    uri = new AlluxioURI("pfs", "baidu.com:123", "/path");
+    Map<String, String> confMap = new HashMap<>();
+    confMap.put(SshUFSPropertyKey.SSH_USERNAME.toString(), "user");
+    confMap.put(SshUFSPropertyKey.SSH_PASSWORD.toString(), "pwd");
+    mUfsConf.setUserSpecifiedConf(confMap);
+    SftpFactory.createSftpClient(uri, mUfsConf);
+
+    Mockito.verify(mSshClientMock, Mockito.times(1)).connect("baidu.com");
+    Mockito.verify(mSshClientMock, Mockito.times(1)).connect("baidu.com", 123);
+    Mockito.verify(mSshClientMock, Mockito.times(1)).authPassword("user", "pwd");
+  }
+
+  @Test
+  public void testAutoConnectClose() throws Exception {
+    SFTPClient client = SftpFactory.createSftpClient(new AlluxioURI("/path"), mUfsConf);
+    // new sftp client created when connecting
+    Mockito.verify(mSshClientMock, Mockito.times(1)).newSFTPClient();
+
+    forwardIdleInterval();
+    SftpFactory.scanIdle();
+
+    // after configured idle interval, the sftp connection will be closed
+    Mockito.verify(mSshClientMock, Mockito.times(1)).close();
+    Mockito.verify(mSftpClientMock, Mockito.times(1)).close();
+
+    client.chmod("/path", 1);
+    // the sftp will be connected again if new interface called
+    Mockito.verify(mSshClientMock, Mockito.times(2)).newSFTPClient();
+  }
+
+  public void testAutoCloseWithReference() throws Exception {
+    SFTPClient client = SftpFactory.createSftpClient(new AlluxioURI("/path"), mUfsConf);
+
+    // open a RemoteFile, the sftp client must be valid before the RemoteFile closed
+    RemoteFile remoteFile = client.open("/path");
+    forwardIdleInterval();
+    SftpFactory.scanIdle();
+    // the sftp client should be auto connected
+    Mockito.verify(mSshClientMock, Mockito.times(1)).newSFTPClient();
+    // but it should not be closed even current time forwarded the configured idle interval
+    Mockito.verify(mSftpClientMock, Mockito.never()).close();
+
+    remoteFile.close();
+    SftpFactory.scanIdle();
+    // now the sftp client should be closed because the remote file closed
+    Mockito.verify(mSftpClientMock).close();
+  }
+
+  public void testCreateStream() throws Exception {
+    RemoteFile remoteFileMock = Mockito.mock(RemoteFile.class);
+    InputStream inputStream = SftpFactory.createInputStream(remoteFileMock, 0);
+    inputStream.close();
+    Mockito.verify(remoteFileMock).close();
+
+    remoteFileMock = Mockito.mock(RemoteFile.class);
+    OutputStream outputStream = SftpFactory.createOutputStream(remoteFileMock);
+    outputStream.close();
+    Mockito.verify(remoteFileMock).close();
+  }
+
+  private void forwardIdleInterval() {
+    long curTime = System.currentTimeMillis();
+    PowerMockito.mockStatic(System.class);
+    long idleInterval = Configuration.getMs(SshUFSPropertyKey.SSH_MAX_IDLE_INTERVAL);
+    long timestamp = curTime + 10 * idleInterval;
+    PowerMockito.when(System.currentTimeMillis()).thenReturn(timestamp);
+  }
+}

--- a/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemContractTest.java
+++ b/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemContractTest.java
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.underfs.AbstractUnderFileSystemContractTest;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+
+import com.google.common.base.Preconditions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This UFS contract test will use {@link SshUnderFileSystem} as the backing store.
+ */
+public class SshUnderFileSystemContractTest extends AbstractUnderFileSystemContractTest {
+  private static final String TEST_PATH_CONF = "testSshUFS";
+  private static final String TEST_PATH = System.getProperty(TEST_PATH_CONF);
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Preconditions.checkNotNull(TEST_PATH, "Test path must be set", TEST_PATH);
+    Preconditions.checkState(new SshUnderFileSystemFactory().supportsPath(TEST_PATH),
+        "%s is not a valid path", TEST_PATH);
+  }
+
+  @Override
+  public UnderFileSystem createUfs(String path, UnderFileSystemConfiguration conf)
+      throws Exception {
+    return new SshUnderFileSystemFactory().create(path, conf);
+  }
+
+  @Override
+  public String getUfsBaseDir() {
+    return TEST_PATH;
+  }
+
+  @Test
+  public void createOpenEmpty() throws IOException {
+    // TODO update the method in base class to allow -1 return value when reading empty file
+  }
+}

--- a/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemFactoryTest.java
+++ b/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.underfs.UnderFileSystemFactory;
+import alluxio.underfs.UnderFileSystemFactoryRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SshUnderFileSystemFactory}.
+ */
+public class SshUnderFileSystemFactoryTest {
+
+  @Test
+  public void factory() {
+    UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("ssh://host/path");
+
+    Assert.assertNotNull(
+        "A UnderFileSystemFactory should exist for ssh paths when using this module", factory);
+  }
+}

--- a/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemTest.java
+++ b/underfs/ssh/src/test/java/alluxio/underfs/ssh/SshUnderFileSystemTest.java
@@ -1,0 +1,260 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ssh;
+
+import alluxio.AlluxioURI;
+import alluxio.Configuration;
+import alluxio.security.authorization.Mode;
+import alluxio.underfs.UfsDirectoryStatus;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.CreateOptions;
+import alluxio.underfs.options.DeleteOptions;
+import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
+
+import net.schmizz.sshj.sftp.FileAttributes;
+import net.schmizz.sshj.sftp.FileMode;
+import net.schmizz.sshj.sftp.PathComponents;
+import net.schmizz.sshj.sftp.PathHelper;
+import net.schmizz.sshj.sftp.RemoteResourceInfo;
+import net.schmizz.sshj.sftp.SFTPClient;
+import net.schmizz.sshj.sftp.SFTPEngine;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for {@link SshUnderFileSystem}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SshUnderFileSystem.class, SftpFactory.class, RemoteIdInfo.class})
+public class SshUnderFileSystemTest {
+  private SFTPClient mSftpClientMock;
+  private RemoteIdInfo mRemoteUserIdInfoMock;
+  private RemoteIdInfo mRemoteGroupIdInfoMock;
+  private SshUnderFileSystem mSshUnderFileSystem;
+
+  @Before
+  public void setup() throws Exception {
+    mSftpClientMock = Mockito.mock(SFTPClient.class);
+    PowerMockito.mockStatic(SftpFactory.class);
+    PowerMockito.when(SftpFactory.createSftpClient(Mockito.anyObject(), Mockito.anyObject()))
+        .thenReturn(mSftpClientMock);
+
+    mRemoteUserIdInfoMock = Mockito.mock(RemoteIdInfo.class);
+    mRemoteGroupIdInfoMock = Mockito.mock(RemoteIdInfo.class);
+    PowerMockito.whenNew(RemoteIdInfo.class)
+        .withArguments(Mockito.any(),
+            Mockito.eq(Configuration.get(SshUFSPropertyKey.SSH_PWDFILE_PATH)))
+        .thenReturn(mRemoteUserIdInfoMock);
+    PowerMockito.whenNew(RemoteIdInfo.class)
+        .withArguments(Mockito.any(),
+            Mockito.eq(Configuration.get(SshUFSPropertyKey.SSH_GROUPFILE_PATH)))
+        .thenReturn(mRemoteGroupIdInfoMock);
+
+    mSshUnderFileSystem = new SshUnderFileSystem(
+        new AlluxioURI("ssh", "host", "/path"), UnderFileSystemConfiguration.defaults());
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    mSshUnderFileSystem.create("p", CreateOptions.defaults());
+
+    Mockito.verify(mSftpClientMock).open(Mockito.eq("p"), Mockito.anyObject(), Mockito.anyObject());
+    PowerMockito.verifyStatic();
+    SftpFactory.createOutputStream(Mockito.anyObject());
+  }
+
+  @Test
+  public void testDeleteDir() throws Exception {
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    // stub the existence and directory type of the path
+    Mockito.when(mSftpClientMock.statExistence(Mockito.anyString()))
+        .thenReturn(attrBuilder.withType(FileMode.Type.DIRECTORY).build());
+    List<RemoteResourceInfo> resourceInfos = new ArrayList<>();
+    resourceInfos.add(new RemoteResourceInfo(
+        new PathComponents("p", "file", "/"),
+        attrBuilder.withType(FileMode.Type.REGULAR).build()));
+    // stub the regular file in the directory path
+    Mockito.when(mSftpClientMock.ls(Mockito.eq("p"))).thenReturn(resourceInfos);
+
+    // first try to delete without recursive
+    DeleteOptions options = DeleteOptions.defaults();
+    mSshUnderFileSystem.deleteDirectory("p", options);
+    Mockito.verify(mSftpClientMock).rmdir(Mockito.eq("p"));
+    Mockito.verify(mSftpClientMock, Mockito.never()).rm(Mockito.anyString());
+
+    // then try to delete with recursive
+    options.setRecursive(true);
+    mSshUnderFileSystem.deleteDirectory("p", options);
+    Mockito.verify(mSftpClientMock, Mockito.times(2)).rmdir(Mockito.eq("p"));
+    Mockito.verify(mSftpClientMock).rm(Mockito.eq("p/file"));
+  }
+
+  @Test
+  public void testDeleteFile() throws Exception {
+    mSshUnderFileSystem.deleteFile("file");
+    Mockito.verify(mSftpClientMock, Mockito.times(1)).rm(Mockito.eq("file"));
+  }
+
+  @Test
+  public void testExists() throws Exception {
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p"))).thenReturn(FileAttributes.EMPTY);
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("q"))).thenReturn(null);
+
+    Assert.assertTrue(mSshUnderFileSystem.exists("p"));
+    Assert.assertFalse(mSshUnderFileSystem.exists("q"));
+  }
+
+  @Test
+  public void testGetDirectoryStatus() throws Exception {
+    Mockito.when(mRemoteUserIdInfoMock.guessName(Mockito.eq(500))).thenReturn("u");
+    Mockito.when(mRemoteGroupIdInfoMock.guessName(Mockito.eq(504))).thenReturn("g");
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    attrBuilder.withUIDGID(500, 504).withPermissions(123);
+    Mockito.when(mSftpClientMock.stat(Mockito.eq("p"))).thenReturn(attrBuilder.build());
+
+    UfsDirectoryStatus status = mSshUnderFileSystem.getDirectoryStatus("p");
+    Assert.assertEquals("p", status.getName());
+    Assert.assertEquals("u", status.getOwner());
+    Assert.assertEquals("g", status.getGroup());
+    Assert.assertEquals(123, status.getMode());
+  }
+
+  @Test
+  public void testGetFileStatus() throws Exception {
+    Mockito.when(mRemoteUserIdInfoMock.guessName(Mockito.eq(500))).thenReturn("u");
+    Mockito.when(mRemoteGroupIdInfoMock.guessName(Mockito.eq(504))).thenReturn("g");
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    attrBuilder.withUIDGID(500, 504).withPermissions(123).withSize(99).withAtimeMtime(88, 77);
+    Mockito.when(mSftpClientMock.stat(Mockito.eq("p"))).thenReturn(attrBuilder.build());
+
+    UfsFileStatus status = mSshUnderFileSystem.getFileStatus("p");
+    Assert.assertEquals("p", status.getName());
+    Assert.assertEquals("u", status.getOwner());
+    Assert.assertEquals("g", status.getGroup());
+    Assert.assertEquals(123, status.getMode());
+    Assert.assertEquals(99, status.getContentLength());
+    Assert.assertEquals(77 * 1000l, (long) status.getLastModifiedTime());
+  }
+
+  @Test
+  public void testIsDirectory() throws Exception {
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p1")))
+        .thenReturn(attrBuilder.withType(FileMode.Type.DIRECTORY).build());
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p2")))
+        .thenReturn(attrBuilder.withType(FileMode.Type.REGULAR).build());
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p3"))).thenReturn(null);
+
+    Assert.assertTrue(mSshUnderFileSystem.isDirectory("p1"));
+    Assert.assertFalse(mSshUnderFileSystem.isDirectory("p2"));
+    Assert.assertFalse(mSshUnderFileSystem.isDirectory("p3"));
+  }
+
+  @Test
+  public void testIsFile() throws Exception {
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p1")))
+        .thenReturn(attrBuilder.withType(FileMode.Type.REGULAR).build());
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p2")))
+        .thenReturn(attrBuilder.withType(FileMode.Type.DIRECTORY).build());
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("p3"))).thenReturn(null);
+
+    Assert.assertTrue(mSshUnderFileSystem.isFile("p1"));
+    Assert.assertFalse(mSshUnderFileSystem.isFile("p2"));
+    Assert.assertFalse(mSshUnderFileSystem.isFile("p3"));
+  }
+
+  @Test
+  public void testListStatus() throws Exception {
+    RemoteResourceInfo info = new RemoteResourceInfo(
+        new PathComponents("p", "file", "/"), FileAttributes.EMPTY);
+    Mockito.when(mSftpClientMock.ls(Mockito.any())).thenReturn(Arrays.asList(info));
+
+    UfsStatus[] status = mSshUnderFileSystem.listStatus("p");
+    Assert.assertEquals(1, status.length);
+  }
+
+  @Test
+  public void testMkdirs() throws Exception {
+    PathHelper pathHelperMock = Mockito.mock(PathHelper.class);
+    Mockito.when(pathHelperMock.getComponents(Mockito.eq("a/b/c")))
+        .thenReturn(new PathComponents("a/b", "c", "/"));
+    Mockito.when(pathHelperMock.getComponents(Mockito.eq("a/b")))
+        .thenReturn(new PathComponents("a", "b", "/"));
+    Mockito.when(pathHelperMock.getComponents(Mockito.eq("a")))
+        .thenReturn(new PathComponents("", "a", "/"));
+
+    SFTPEngine engineMock = Mockito.mock(SFTPEngine.class);
+    Mockito.when(engineMock.getPathHelper()).thenReturn(pathHelperMock);
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    attrBuilder.withType(FileMode.Type.DIRECTORY);
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("/a"))).thenReturn(attrBuilder.build());
+    Mockito.when(mSftpClientMock.getSFTPEngine()).thenReturn(engineMock);
+    // to throw exception when setting owners
+    Mockito.doThrow(new IOException()).when(mSftpClientMock)
+        .setattr(Mockito.eq("a/b"), Mockito.any());
+
+    Mode mode = new Mode((short) 123);
+    MkdirsOptions options = MkdirsOptions.defaults().setCreateParent(true).setMode(mode);
+    mSshUnderFileSystem.mkdirs("a/b/c", options);
+
+    ArgumentCaptor<FileAttributes> argument = ArgumentCaptor.forClass(FileAttributes.class);
+    Mockito.verify(engineMock).makeDir(Mockito.eq("a/b"), argument.capture());
+    Assert.assertEquals(123, argument.getValue().getMode().getMask());
+    Mockito.verify(engineMock).makeDir(Mockito.eq("a/b/c"), Mockito.any());
+    Mockito.verify(mSftpClientMock).setattr(Mockito.eq("a/b"), Mockito.any());
+  }
+
+  @Test
+  public void testOpen() throws Exception {
+    mSshUnderFileSystem.open("p", OpenOptions.defaults().setOffset(10));
+    Mockito.verify(mSftpClientMock, Mockito.times(1)).open(Mockito.eq("p"));
+    PowerMockito.verifyStatic();
+    SftpFactory.createInputStream(Mockito.any(), Mockito.eq(10L));
+  }
+
+  @Test
+  public void testRename() throws Exception {
+    FileAttributes.Builder attrBuilder = new FileAttributes.Builder();
+    attrBuilder.withType(FileMode.Type.DIRECTORY);
+    Mockito.when(mSftpClientMock.statExistence(Mockito.eq("src"))).thenReturn(attrBuilder.build());
+    mSshUnderFileSystem.renameDirectory("src", "dest");
+    Mockito.verify(mSftpClientMock).rename(Mockito.eq("src"), Mockito.eq("dest"));
+  }
+
+  @Test
+  public void testSetOwner() throws Exception {
+    mSshUnderFileSystem.setOwner("p", "u", "g");
+    Mockito.verify(mSftpClientMock).setattr(Mockito.eq("p"), Mockito.any());
+  }
+
+  @Test
+  public void testSetMode() throws Exception {
+    mSshUnderFileSystem.setMode("p", (short) 123);
+    Mockito.verify(mSftpClientMock).chmod(Mockito.eq("p"), Mockito.eq(123));
+  }
+}

--- a/underfs/ssh/src/test/resources/log4j.properties
+++ b/underfs/ssh/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.root.logger=INFO, TEST_LOGGER
+alluxio.log.dir=./target/logs
+alluxio.log.file=tests.log
+
+log4j.rootLogger=${alluxio.root.logger}
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+
+#Test Logger
+log4j.appender.TEST_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.TEST_LOGGER.File=${alluxio.log.dir}/${alluxio.log.file}
+log4j.appender.TEST_LOGGER.MaxFileSize=10MB
+log4j.appender.TEST_LOGGER.MaxBackupIndex=100
+log4j.appender.TEST_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.TEST_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n


### PR DESCRIPTION
https://alluxio.atlassian.net/browse/ALLUXIO-3283

It is implemented by SSH's java implementation [sshj](https://github.com/hierynomus/sshj), using the sub-protocol [sftp](https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol). Sftp works nested in SSH, without a dependent server, only four parameters are needed when mounting local file  to Alluxio: host, path, user name and password.

There are two problems should be resolved.
1. User id and group id are transferred by sftp instead of the user name and group name. So **I provided a class RemoteIdInfo to transform id to correspond name**. It is implemented by fetching /etc/passwd and /etc/group using sftp, then fetch user name from id by parsing file /etc/passwd, and group name can be parsed same way. These two files may not be accessed some times, so the best effort strategy is used.

2. Managing the SSH connection. Two simple design: establish the connection when required and never close it; establish the connection each time required and close it immediately after the sftp operation. Its obviously that both designs can not be used in product circumstance.
So I am using another design, **establish the connection when required, and close it if no operation happened for certain duration**. SFTPClient from sshj does not support this logic, so I implemented by proxying the SFTPClient. Sftp connection is established when method of SFTPClient instance is called, a timestamp is updated when any method of the instance is called, a reference number increased when input/output stream generated from the instance, and the reference number decreased when the stream released. The instance is monitored by a separate thread, and will be released when the the reference number is 0 and the last update time is older than a configured threshold. It is implemented by class SftpFactory.


Usage:
`./bin/alluxio fs mount --option ssh.username=<username> --option ssh.password=<pwd> /mnt/local ssh://<host>/<path>`
Please make sure that the host can be logged in from Alluxio master by SSH.