### PR TITLE
Support Huawei PFS

### DIFF
--- a/underfs/obs/pom.xml
+++ b/underfs/obs/pom.xml
@@ -16,7 +16,7 @@
   <artifactId>alluxio-underfs-obs</artifactId>
   <name>Alluxio Under File System - Huawei OBS</name>
   <description>Huawei OBS Under File System implementation</description>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.7.0-SNAPSHOT</version>
 
   <repositories>
     <repository>

--- a/underfs/obs/pom.xml
+++ b/underfs/obs/pom.xml
@@ -55,13 +55,13 @@
   </repositories>
 
   <properties>
-    <alluxio.version>2.0.0-SNAPSHOT</alluxio.version>
+    <alluxio.version>2.2.1</alluxio.version>
     <hamcrest.version>1.3</hamcrest.version>
     <java.version>1.8</java.version>
     <junit.version>4.12</junit.version>
     <maven.version>3.3.9</maven.version>
     <mockito.version>1.10.8</mockito.version>
-    <obs.version>2.1.18</obs.version>
+    <obs.version>3.20.6</obs.version>
     <powermock.version>1.6.1</powermock.version>
   </properties>
 

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSInputStream.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSInputStream.java
@@ -18,7 +18,7 @@ import com.obs.services.ObsClient;
 import com.obs.services.exception.ObsException;
 import com.obs.services.model.GetObjectRequest;
 import com.obs.services.model.ObjectMetadata;
-import com.obs.services.model.S3Object;
+import com.obs.services.model.ObsObject;
 import org.apache.commons.httpclient.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +99,7 @@ public class OBSInputStream extends MultiRangeObjectInputStream {
     ObsException lastException = null;
     while (mRetryPolicy.attempt()) {
       try {
-        S3Object obj = mObsClient.getObject(req);
+        ObsObject obj = mObsClient.getObject(req);
         return new BufferedInputStream(obj.getObjectContent());
       } catch (ObsException e) {
         System.out.println(e.getResponseCode());

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSPropertyKey.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSPropertyKey.java
@@ -27,7 +27,9 @@ public final class OBSPropertyKey {
       .setDescription("The endpoint of OBS bucket.").build();
   public static final PropertyKey OBS_SECRET_KEY = new PropertyKey.Builder(Name.OBS_SECRET_KEY)
       .setDescription("The secret key of OBS bucket.").build();
-
+  public static final PropertyKey OBS_BUCKET_TYPE = new PropertyKey.Builder(Name.OBS_BUCKET_TYPE)
+          .setDefaultValue("obs")
+          .setDescription("The type of bucket (obs/pfs),the default value is obs.").build();
   /**
    * Name for OBS configuration property keys.
    */
@@ -36,5 +38,6 @@ public final class OBSPropertyKey {
     public static final String OBS_ACCESS_KEY = "fs.obs.accessKey";
     public static final String OBS_ENDPOINT = "fs.obs.endpoint";
     public static final String OBS_SECRET_KEY = "fs.obs.secretKey";
+    public static final String OBS_BUCKET_TYPE = "fs.obs.bucketType";
   }
 }

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSUnderFileSystem.java
@@ -93,8 +93,8 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
    * @param bucketName bucket name of user's configured Alluxio bucket
    * @param conf configuration for this UFS
    */
-  protected OBSUnderFileSystem(AlluxioURI uri, ObsClient obsClient, String bucketName, String bucketType,
-      UnderFileSystemConfiguration conf) {
+  protected OBSUnderFileSystem(AlluxioURI uri, ObsClient obsClient, String bucketName,
+                               String bucketType, UnderFileSystemConfiguration conf) {
     super(uri, conf);
     mClient = obsClient;
     mBucketName = bucketName;
@@ -125,6 +125,7 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
       return true;
     } catch (ObsException e) {
       LOG.error("Failed to rename file {} to {}", src, dst, e);
+      System.out.println("Failed to rename file " + src + " execption:" + e);
       return false;
     }
   }
@@ -192,7 +193,7 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
               && !isDirectory(request.getPrefix())) {
         result = null;
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       LOG.warn("Failed to list path {}", request.getPrefix(), e);
       result = null;
     }
@@ -201,8 +202,9 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
 
   private boolean isDirectoryInPFS(ObjectMetadata meta) {
     int mode = Integer.parseInt(meta.getMetadata().get("mode").toString());
-    if (mode < 0)
+    if (mode < 0) {
       return false;
+    }
     int ifDIr = 0x004000;
     return (ifDIr & mode) != 0;
   }
@@ -268,7 +270,8 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
         /**
          * When in PFS environment:
          * 1. Directory will be explicitly created and have object meta.
-         * 2. File will have object meta even if there is `/` at the end of the file name (e.g. `/dir1/file1/`)
+         * 2. File will have object meta even if there is `/` at
+         *    the end of the file name (e.g. `/dir1/file1/`).
          * However we should return null meta here.
          */
         if (isDirectoryInPFS(meta)) {
@@ -319,7 +322,8 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
-  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy) throws IOException {
+  protected InputStream openObject(String key, OpenOptions options,
+                                   RetryPolicy retryPolicy) throws IOException {
     try {
       return new OBSInputStream(mBucketName, key, mClient, options.getOffset(), retryPolicy,
           mUfsConf.getBytes(PropertyKey.UNDERFS_OBJECT_STORE_MULTI_RANGE_CHUNK_SIZE));
@@ -334,7 +338,8 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
       return super.renameDirectory(src, dst);
     }
     try {
-      RenameRequest request = new RenameRequest(mBucketName, stripPrefixIfPresent(src), stripPrefixIfPresent(dst));
+      RenameRequest request = new RenameRequest(mBucketName, stripPrefixIfPresent(src),
+              stripPrefixIfPresent(dst));
       RenameResult response = mClient.renameFolder(request);
       if (isSuccessResponse(response.getStatusCode())) {
         return true;
@@ -347,12 +352,10 @@ public class OBSUnderFileSystem extends ObjectUnderFileSystem {
       return false;
     }
   }
-
   /**
    * @param statusCode 200 OK, 201 Created, 204 No Content
    */
   private boolean isSuccessResponse(int statusCode) {
-    return statusCode == 200 || statusCode == 204;
+    return statusCode == 200 || statusCode == 204 || statusCode == 201;
   }
-
 }

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
@@ -27,7 +27,7 @@ import alluxio.util.ConfigurationUtils;
 
 import com.obs.services.ObsClient;
 import com.obs.services.model.GetObjectRequest;
-import com.obs.services.model.S3Object;
+import com.obs.services.model.ObsObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class OBSInputStreamTest {
   private OBSInputStream mOBSInputStream;
   private ObsClient mObsClient;
   private InputStream[] mInputStreamSpy;
-  private S3Object[] mObjects;
+  private ObsObject[] mObjects;
 
   /**
    * The exception expected to be thrown.
@@ -65,11 +65,11 @@ public class OBSInputStreamTest {
     mObsClient = mock(ObsClient.class);
 
     byte[] input = new byte[] {1, 2, 3};
-    mObjects = new S3Object[input.length];
+    mObjects = new ObsObject[input.length];
     mInputStreamSpy = new InputStream[input.length];
     for (int i = 0; i < input.length; ++i) {
       final long pos = (long) i;
-      mObjects[i] = mock(S3Object.class);
+      mObjects[i] = mock(ObsObject.class);
       when(mObsClient.getObject(argThat(new ArgumentMatcher<GetObjectRequest>() {
         @Override
         public boolean matches(Object argument) {


### PR DESCRIPTION
PFS is an extension of OBS. 
1. The main difference is  dir in PFS will be explicitly created . But other storage (like s3,obs....) won't create a real dir.
(when PFS,  `OBSUnderFileSystem#getObjectStatus`will return meta in dir , but we want null.).
This will cause dir be considered as a file in some conditions and files in this dir won't be listed.

2.  Assuming this scenario: 
    `/xx/file1/` ( File1 actually exists, which is a file) , but we should pay attention, there is `/` after file1 name.
     When OBS , the path object meta is null.
     When PFS, the path object meta is not null. The object meta is same as `/xx/file1`
     
3.  PFS supports `Rename` directory , OBS doesn't support.

4. Assuming this scenario: 
   There are several files as follows: /dir1, /dir1/file1
   When OBS (also s3...) ,   delete `/dir1` ---> dir1 & file1 all exists.   Then delete `/dir1/file1`, dir1 & file1 all are deleted. 
   When PFS ,  delete `/dir1` ---> dir1 & file1 all exists.   Then delete `/dir1/file1`, file1 is deleted, dir1 is not deleted.
   This means that when PFS, We should first  delete `/dir1/file1`, then delete `/dir1`.